### PR TITLE
fix No such file or directory @ rb_sysopen - country_lookup_table.yml

### DIFF
--- a/lib/free_zipcode_data/db_table.rb
+++ b/lib/free_zipcode_data/db_table.rb
@@ -24,7 +24,11 @@ module FreeZipcodeData
     private
 
     def country_lookup_table
-      @country_lookup_table ||= YAML.load_file('country_lookup_table.yml')
+      @country_lookup_table ||=
+        begin
+          path = File.expand_path('../../country_lookup_table.yml', __dir__)
+          YAML.load_file(path)
+        end
     end
 
     def select_first(sql)

--- a/lib/free_zipcode_data/runner.rb
+++ b/lib/free_zipcode_data/runner.rb
@@ -35,7 +35,9 @@ module FreeZipcodeData
 
       db_file = File.join(options.work_dir, 'free_zipcode_data.sqlite3')
       database = SqliteRam.new(db_file)
-      configure_meta(database.conn, datasource.datafile)
+
+      line_count = datasource_line_count(datasource.datafile)
+      configure_meta(database.conn, line_count)
 
       %i[country state county zipcode].each { |t| initialize_table(t, database) }
 
@@ -50,7 +52,7 @@ module FreeZipcodeData
       end
 
       elapsed = Time.at(Time.now - start_time).utc.strftime('%H:%M:%S')
-      logger.info("Processed #{datasource_line_count(datasource.datafile)} zipcodes in [#{elapsed}].".yellow)
+      logger.info("Processed #{line_count} zipcodes in [#{elapsed}].".yellow)
     end
 
     private
@@ -67,14 +69,12 @@ module FreeZipcodeData
     end
 
     def datasource_line_count(filename)
-      @datasource_line_count ||= begin
-        count = File.foreach(filename).inject(0) { |c, _line| c + 1 }
-        logger.verbose("Processing #{count} zipcodes in '#{filename}'...")
-        count
-      end
+      count = File.foreach(filename).inject(0) { |c, _line| c + 1 }
+      logger.verbose("Processing #{count} zipcodes in '#{filename}'...")
+      count
     end
 
-    def configure_meta(database, datasource)
+    def configure_meta(database, line_count)
       schema = <<-SQL
         create table meta (
           id integer not null primary key,
@@ -86,7 +86,7 @@ module FreeZipcodeData
 
       sql = <<-SQL
         INSERT INTO meta (name, value)
-        VALUES ('line_count', #{datasource_line_count(datasource)})
+        VALUES ('line_count', #{line_count})
       SQL
       database.execute(sql)
     end

--- a/lib/free_zipcode_data/runner.rb
+++ b/lib/free_zipcode_data/runner.rb
@@ -50,7 +50,7 @@ module FreeZipcodeData
       end
 
       elapsed = Time.at(Time.now - start_time).utc.strftime('%H:%M:%S')
-      logger.info("Processed #{datasource_line_count} zipcodes in [#{elapsed}].".yellow)
+      logger.info("Processed #{datasource_line_count(datasource.datafile)} zipcodes in [#{elapsed}].".yellow)
     end
 
     private


### PR DESCRIPTION
Related Issue: #12



```
root@502c0371a4ae:/app# free_zipcode_data --work-dir /tmp/geodata --generate-files --verbose
Starting FreeZipcodeData v1.0.1...
File: /tmp/geodata/allCountries.txt.csv already exists, skipping...
Processing 1264588 zipcodes in '/tmp/geodata/allCountries.txt.csv'...
Initializing country table: 'countries'...
Initializing state table: 'states'...                                                                                   |  ETA: ??:??:??
Initializing county table: 'counties'...                                                                                |  ETA: ??:??:??
Initializing zipcode table: 'zipcodes'...                                                                               |  ETA: ??:??:??
Processing '/tmp/geodata/allCountries.txt.csv' data, please be patient...                                               |  ETA: ??:??:??
Finished generating table data...================================================================================       |  ETA: 00:00:25
Saving database to disk '/tmp/geodata/free_zipcode_data.sqlite3'...
Generating .csv files...
Processed 1264588 zipcodes in [00:08:01].
root@502c0371a4ae:/app#
```